### PR TITLE
Free allocated memory in GetXmlTag to avoid leaking memory

### DIFF
--- a/wiiu/src/main.cpp
+++ b/wiiu/src/main.cpp
@@ -115,12 +115,19 @@ std::string GetXmlTag(std::string tag) {
     std::string result;
     ACPInitialize();
     auto *metaXml = (ACPMetaXml *) memalign(0x40, sizeof(ACPMetaXml));
-    if (ACPGetTitleMetaXml(OSGetTitleID(), metaXml) == ACP_RESULT_SUCCESS) {
-        if (tag == "longname_en") result       = metaXml->longname_en;
-        else if (tag == "shortname_en") result = metaXml->shortname_en;
-        else result.clear();
-    } else {
-        result.clear();
+    if (metaXml)
+    {
+        if (ACPGetTitleMetaXml(OSGetTitleID(), metaXml) == ACP_RESULT_SUCCESS)
+        {
+            if (tag == "longname_en") result = metaXml->longname_en;
+            else if (tag == "shortname_en") result = metaXml->shortname_en;
+            else result.clear();
+        }
+        else
+        {
+            result.clear();
+        }
+        free(metaXml);
     }
     ACPFinalize();
     return result;


### PR DESCRIPTION
Currently the plugin leaks ~13KiB every 5 seconds. After around 5 hours this will consume the whole heap and the console will crash